### PR TITLE
Only three Tags are allowed on Questions

### DIFF
--- a/wp_core/admin.py
+++ b/wp_core/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from wp_core.forms import QuestionForm
 from wp_core.models import (
         Question,
         Answer,
@@ -7,8 +8,13 @@ from wp_core.models import (
         Tag
     )
 
-# Register your models here.
-admin.site.register(Question)
+
+class QuestionAdmin(admin.ModelAdmin):
+    form = QuestionForm
+    filter_horizontal = ('tags',)
+
+
+admin.site.register(Question, QuestionAdmin)
 admin.site.register(Answer)
 admin.site.register(VoteQuestion)
 admin.site.register(VoteAnswer)

--- a/wp_core/forms.py
+++ b/wp_core/forms.py
@@ -1,0 +1,16 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from wp_core.models import Question
+
+
+class QuestionForm(forms.ModelForm):
+    class Meta:
+        model = Question
+        fields = '__all__'
+
+    def clean(self):
+        tags = self.cleaned_data.get('tags')
+        if tags and tags.count() > 3:
+            raise ValidationError('Only three Tags allowed')
+
+        return self.cleaned_data

--- a/wp_core/serializers.py
+++ b/wp_core/serializers.py
@@ -66,6 +66,11 @@ class QuestionSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError('Question already exists')
         return value
 
+    def validate_tags(self, value):
+        if len(value) > 3:
+            raise serializers.ValidationError('Only 3 Tags are allowed')
+        return value
+
 
 class QuestionLinkSerializer(serializers.HyperlinkedModelSerializer):
 


### PR DESCRIPTION
On Creation and Changing of Questions, it is now checked, weather there
are more than 3 tags selected.
This applies to the admin panel as well as the api. The admin panel now
also has a nicer selector for the Tags.

fixes #8 