### PR TITLE
Add 0 to sum of votes, when up=false

### DIFF
--- a/wp_core/views.py
+++ b/wp_core/views.py
@@ -63,6 +63,7 @@ class QuestionsViewSet(viewsets.ModelViewSet):
                 upvotes=Sum(
                         Case(
                             When(votequestion__up=True, then=1),
+                            When(votequestion__up=False, then=0),
                             output_field=IntegerField()
                         )
                     )

--- a/wp_core/views_answers.py
+++ b/wp_core/views_answers.py
@@ -23,6 +23,7 @@ class AnswerViewSet(viewsets.ModelViewSet):
                 upvotes=Sum(
                     Case(
                         When(voteanswer__up=True, then=1),
+                        When(voteanswer__up=False, then=0),
                         output_field=IntegerField()
                     )
                 )


### PR DESCRIPTION
This prevents the sum to be uninitialized and returning null for the
upvote count.
Also fixes this for the Answers

fixes #68 